### PR TITLE
fix: add missing build step to setup instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,17 @@ Go to your fork on GitHub and click "Compare & pull request".
    ```
    You can get your Public API key from the [JigsawStack Dashboard](https://jigsawstack.com).
 
-3. **Start the development server:**
+3. **Build the project:**
+   ```bash
+   npm run build
+   ```
+   or
+   ```bash
+   yarn build
+   ```
+   This creates the `dist/` directory with the compiled library files that the demo HTML requires.
+
+4. **Start the development server:**
    ```bash
    npm run dev
    ```
@@ -77,7 +87,7 @@ Go to your fork on GitHub and click "Compare & pull request".
    yarn dev
    ```
 
-3. **Open your browser and visit:**
+5. **Open your browser and visit:**
    ```
    http://localhost:5173
    ```

--- a/index.html
+++ b/index.html
@@ -112,7 +112,7 @@
             console.log(res);
         }, (err)=>{
             console.log(err);
-        })" class="tw-button notranslate">Translat to hindi</button>
+        })" class="tw-button notranslate">Translate to hindi</button>
 
         <button onclick="window.resetTranslation('en', (res)=>{
             console.log(res);


### PR DESCRIPTION
fixes #43

- Add build step: Include `npm run build` or `yarn build` in the setup instructions before starting the dev server
- Fix typo: Correct "Translat to hindi" → "Translate to hindi" in the demo button text
- The demo HTML loads a pre-built library file (`dist/index.min.js`) but the setup instructions were missing the build step that creates this file. This caused the mentioned issue

![image](https://github.com/user-attachments/assets/81c7e591-949e-4982-821c-2d5e5b68e36e)
